### PR TITLE
Use wrapPick with dynamic imports; make wrapPick synchronous

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,27 +24,30 @@ async function getProfile(userId: string) {
 With typectl, you describe **what depends on what** and the runtime figures out the rest:
 
 ```typescript
-import { wrap } from "typectl"
+import { wrapPick } from "typectl"
 
-const fetchUserW = wrap(fetchUser)
-const fetchPostsW = wrap(fetchPosts)
-const formatProfileW = wrap(formatProfile)
+const functions = import("./functions")
+const fetchUser = wrapPick(functions, "fetchUser")
+const fetchPosts = wrapPick(functions, "fetchPosts")
+const formatProfile = wrapPick(functions, "formatProfile")
 
 function getProfile(userId: string) {
-  const user = fetchUserW(userId)
-  const posts = fetchPostsW(userId)            // runs concurrently with fetchUser
-  const profile = formatProfileW(user, posts)  // waits for both, then runs
+  const user = fetchUser(userId)
+  const posts = fetchPosts(userId)            // runs concurrently with fetchUser
+  const profile = formatProfile(user, posts)  // waits for both, then runs
   return profile
 }
 ```
 
-No `async`. No `await`. No `Promise.all`. The function reads like synchronous code, returns a `Promise`, and the library resolves the dependency graph for you.
+No `async`. No `await`. No `Promise.all`. No static imports. `wrapPick` extracts each function from the dynamic import and returns an immediately callable wrapper. The library resolves the dependency graph for you.
 
-## Core concept
+## Core concepts
 
-The key primitive is `wrap`. Wrapping a function makes every argument accept either a plain value **or** a `Promise` of that value. The wrapper resolves all arguments with `Promise.all` before calling the inner function, and always returns a `Promise`.
+**`wrap`** — Wrapping a function makes every argument accept either a plain value **or** a `Promise` of that value. The wrapper resolves all arguments before calling the inner function, and always returns a `Promise`. Since `wrap` also accepts a `Promise<Function>`, it works seamlessly with dynamic imports.
 
-By passing promise return values to successive wrapped functions, you build a dependency graph that resolves itself optimally at runtime.
+**`wrapPick`** — Combines a dynamic `import()` with property extraction and wrapping in a single step. The result is an immediately callable wrapped function — no `await`, no static imports.
+
+By passing promise return values to successive wrapped functions, you build a dependency graph that resolves itself optimally at runtime. `await` only appears at the final consumption boundary.
 
 ## Example
 
@@ -80,22 +83,22 @@ export function formatProfile(
 ### `controlFlow.ts`
 
 ```typescript
-import { wrap } from "typectl"
-import { fetchUser, fetchPosts, formatProfile } from "./functions"
+import { wrapPick } from "typectl"
 
-const fetchUserW = wrap(fetchUser)
-const fetchPostsW = wrap(fetchPosts)
-const formatProfileW = wrap(formatProfile)
+const functions = import("./functions")
+const fetchUser = wrapPick(functions, "fetchUser")
+const fetchPosts = wrapPick(functions, "fetchPosts")
+const formatProfile = wrapPick(functions, "formatProfile")
 
 export default function getProfile(userId: string) {
-  const user = fetchUserW(userId)
-  const posts = fetchPostsW(userId)
-  const profile = formatProfileW(user, posts)
+  const user = fetchUser(userId)
+  const posts = fetchPosts(userId)
+  const profile = formatProfile(user, posts)
   return { user, posts, profile }
 }
 ```
 
-There is no `await` anywhere in `getProfile`. `fetchUser` and `fetchPosts` run concurrently because neither depends on the other. `formatProfile` automatically waits for both before running. The dependency graph:
+There is no `await` anywhere and no static function imports — each function is dynamically imported and wrapped in a single expression. `fetchUser` and `fetchPosts` run concurrently because neither depends on the other. `formatProfile` automatically waits for both before running. The dependency graph:
 
 ```
 fetchUser ──┐
@@ -147,9 +150,9 @@ import { wrap } from "typectl"
 
 const add = wrap((a: number, b: number) => a + b)
 
-await add(1, 2)                        // → 3
-await add(Promise.resolve(1), 2)       // → 3
-await add(fetch("/a"), fetch("/b"))    // resolves both, then adds
+const three = add(1, 2)                // → Promise<3>
+const six = add(three, 3)              // chains without await → Promise<6>
+add(fetch("/a"), fetch("/b"))          // resolves both, then adds
 ```
 
 Wrapping is memoized — `wrap(fn) === wrap(fn)` — so you can call it freely without creating duplicate wrappers.
@@ -157,10 +160,10 @@ Wrapping is memoized — `wrap(fn) === wrap(fn)` — so you can call it freely w
 `wrap` also accepts a `Promise<Function>`, which is useful with dynamic imports:
 
 ```typescript
-const fn = wrap(
+const add = wrap(
   import("./math").then((m) => m.add)
 )
-await fn(1, 2) // → 3
+add(1, 2) // → Promise<3>
 ```
 
 ### `pick(object, key)`
@@ -170,30 +173,29 @@ Extracts a property from an object or a `Promise` of an object. If the property 
 ```typescript
 import { pick } from "typectl"
 
-// With dynamic imports — no await needed
+// With dynamic imports
 const functions = import("./math")
-const add = pick(functions, "add")     // Promise<wrapped add>
-const result = (await add)(1, 2)       // → 3
+const add = pick(functions, "add")     // → Promise<wrapped add>
 
 // With plain objects
 const config = { port: 3000 }
-await pick(config, "port")             // → 3000
+pick(config, "port")                   // → Promise<3000>
 ```
 
 Throws an `Error` if the resolved object is `undefined`.
 
 ### `wrapPick(object, key)`
 
-Like `pick`, but unconditionally wraps the result with `wrap`. Useful when you need to guarantee a property goes through wrapping even if the type is broad.
+Picks a named property from an object (or `Promise` of one) and wraps it with `wrap`. Because `wrap` accepts a `Promise<Function>`, the returned wrapper is immediately callable — no `await` needed.
 
 ```typescript
 import { wrapPick } from "typectl"
 
-const add = await wrapPick(
-  import("./math"),
-  "add"
-)
-await add(Promise.resolve(1), 2) // → 3
+const functions = import("./math")
+const add = wrapPick(functions, "add")
+const multiply = wrapPick(functions, "multiply")
+
+const result = add(1, multiply(2, 3))  // → Promise<7>, no await needed
 ```
 
 ### `all(array)`
@@ -393,10 +395,11 @@ Like `Object.assign`, but every argument may be a `Promise`. All arguments are r
 ```typescript
 import { assign } from "typectl"
 
-const merged = await assign(
+const merged = assign(
   fetch("/defaults").then((r) => r.json()),
   fetch("/overrides").then((r) => r.json())
 )
+// → Promise<merged object> — pass to other wrapped functions or await at the boundary
 ```
 
 ### `promiseCall(value)`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ function getProfile(userId: string) {
 }
 ```
 
-No `async`. No `await`. No `Promise.all`. No static imports. `wrapPick` extracts each function from the dynamic import and returns an immediately callable wrapper. The library resolves the dependency graph for you.
+No `async`. No `await`. No `Promise.all`. No manual promise wiring. Two properties make this work beautifully:
+
+**You never `await` until you need a final result.** The entire control flow reads like synchronous code. You only `await` at the boundary where you actually need a resolved value — a test assertion, an HTTP response, a rendered template. Everything before that is just describing relationships between computations.
+
+**Everything stays fully typed — without writing a single type annotation.** `wrapPick` infers each function's parameter types and return type directly from the dynamic import. In the example above, `user` is typed as `Promise<{ id: string; name: string; email: string }>` and `profile` carries the full return type of `formatProfile` — all without any explicit type declarations in the control flow. The type system follows the data through every step automatically.
 
 ## Core concepts
 

--- a/src/example/controlFlow.ts
+++ b/src/example/controlFlow.ts
@@ -1,17 +1,13 @@
-import { wrap } from "../typectl"
-import {
-  fetchUser,
-  fetchPosts,
-  formatProfile,
-} from "./functions"
+import { wrapPick } from "../typectl"
 
-const fetchUserW = wrap(fetchUser)
-const fetchPostsW = wrap(fetchPosts)
-const formatProfileW = wrap(formatProfile)
+const functions = import("./functions")
+const fetchUser = wrapPick(functions, "fetchUser")
+const fetchPosts = wrapPick(functions, "fetchPosts")
+const formatProfile = wrapPick(functions, "formatProfile")
 
 export default function getProfile(userId: string) {
-  const user = fetchUserW(userId)
-  const posts = fetchPostsW(userId)
-  const profile = formatProfileW(user, posts)
+  const user = fetchUser(userId)
+  const posts = fetchPosts(userId)
+  const profile = formatProfile(user, posts)
   return { user, posts, profile }
 }

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -52,7 +52,9 @@ export function wrapPick<
     : Exclude<T, undefined>,
   K extends keyof V,
 >(item: T, k: K): WrappedFunctionType<V[K], never> {
-  return wrap(pick(item, k)) as unknown as WrappedFunctionType<V[K], never>
+  return wrap(
+    pick(item, k)
+  ) as unknown as WrappedFunctionType<V[K], never>
 }
 
 /**

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -36,28 +36,23 @@ export function pick<
 
 /**
  * Picks a named property from an object (or `Promise` of one)
- * and unconditionally wraps it with {@link wrap}. Unlike
- * {@link pick}, the returned `Promise` always resolves to a
- * wrapped function — useful when you need to guarantee that a
- * known-function property goes through `wrap` even when the
- * object type is broad.
+ * and wraps it with {@link wrap}. Because `wrap` accepts a
+ * `Promise<Function>`, the returned wrapper is immediately
+ * callable — no `await` needed.
  *
- * @remarks Because this function is `async`, it must be
- * `await`ed or passed as a `Promise` argument to another
- * wrapped function.
+ * @example
+ * const functions = import("./math")
+ * const add = wrapPick(functions, "add")
+ * add(1, 2) // → Promise<3>
  */
-export async function wrapPick<
+export function wrapPick<
   T extends Promise<Record<any, any>> | Record<any, any>,
   V extends T extends Promise<infer V>
     ? Exclude<V, undefined>
     : Exclude<T, undefined>,
   K extends keyof V,
->(
-  item: T,
-  k: K
-): Promise<WrappedFunctionType<V[K], never>> {
-  const fn = await pick(item, k)
-  return wrap(fn)
+>(item: T, k: K): WrappedFunctionType<V[K], never> {
+  return wrap(pick(item, k)) as unknown as WrappedFunctionType<V[K], never>
 }
 
 /**

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -48,7 +48,7 @@ describe("typectl", () => {
   })
 
   it("wrapPick", async () => {
-    const fn = await wrapPick(
+    const fn = wrapPick(
       { x: (x: string, y: Promise<string>) => [x, y] },
       "x"
     )


### PR DESCRIPTION
## Summary

- `wrapPick` is now synchronous — it composes `wrap(pick(...))` directly and returns an immediately callable wrapped function instead of a `Promise<WrappedFunction>`. No `await` needed at the call site.
- The `src/example/controlFlow.ts` example is updated to use a single `import()` variable with `wrapPick` for each function — no static imports, no `wrap` calls.
- README updated throughout: the \"Why typectl?\", \"Core concepts\", and all relevant API sections now showcase promise-chaining without `await`, with `wrapPick` elevated as a key primitive alongside `wrap`.

## Test plan

- [ ] `npm test` passes (38 tests)
- [ ] `wrapPick` no longer requires `await` at the call site
- [ ] Dynamic import pattern works end-to-end in `src/example/spec.ts`

Made with [Cursor](https://cursor.com)