### PR TITLE
fix: sequential toValue, plain-object guard in iterate, real coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,9 @@ Iterates over a `ReadableStream`, array, or plain-object record, invoking `callb
 |-------|-----------|-------------------|
 | `ReadableStream` | Sequential | `(value) => any` |
 | `Array` | Concurrent (`Promise.all`) | `(value, index) => any` |
-| `Record` | Concurrent (`Promise.all`) | `(value, key) => any` |
+| `Record` (plain objects only) | Concurrent (`Promise.all`) | `(value, key) => any` |
+
+> **Note:** Only plain objects (`{}` literals and `Object.create(null)`) are accepted as records. Class instances are not iterated.
 
 ```typescript
 import { iterate } from "typectl"
@@ -359,6 +361,8 @@ The optional `callback` receives `(value, index|key, accumulator)` and should re
 
 Without a callback, the last non-`undefined` element is returned.
 
+All input types are processed **sequentially**, so stateful accumulation is always deterministic regardless of whether callbacks are async.
+
 ```typescript
 import { toValue } from "typectl"
 
@@ -378,8 +382,6 @@ await toValue([1, 5, 3], (v, _i, acc) =>
 )
 // → 5
 ```
-
-> **Note:** For array inputs, callbacks run concurrently. Stateful reduction with async callbacks may yield non-deterministic results. Use a `ReadableStream` input for guaranteed sequential reduction.
 
 ### `tee(stream)`
 

--- a/src/iterate.ts
+++ b/src/iterate.ts
@@ -16,8 +16,10 @@ import { getReadableStream } from "./polyfill"
  * - `Array`: all callbacks are fired **concurrently** via
  *   `Promise.all`. The completion order of async callbacks is
  *   therefore non-deterministic.
- * - `Record`: same concurrent semantics as arrays, iterating
- *   only own enumerable string keys (`Object.entries`).
+ * - `Record` (plain objects only — `Object.create(null)` or
+ *   `{}` literals): same concurrent semantics as arrays,
+ *   iterating own enumerable string keys (`Object.entries`).
+ *   Class instances are not treated as records and are skipped.
  *
  * Both `iterable` and `callback` may themselves be
  * `Promise`-wrapped; they are resolved before iteration
@@ -55,7 +57,12 @@ export async function iterate<
         )
       )
     )
-  } else if (typeof iterable === "object") {
+  } else if (
+    iterable !== null &&
+    typeof iterable === "object" &&
+    (Object.getPrototypeOf(iterable) === Object.prototype ||
+      Object.getPrototypeOf(iterable) === null)
+  ) {
     await Promise.all(
       Object.entries(
         iterable as Record<string, unknown>

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -293,7 +293,10 @@ export async function toValue<
     for (let i = 0; i < (iterable as any[]).length; i++) {
       await apply((iterable as any[])[i], i)
     }
-  } else if (typeof iterable === "object" && iterable !== null) {
+  } else if (
+    typeof iterable === "object" &&
+    iterable !== null
+  ) {
     for (const [key, val] of Object.entries(
       iterable as Record<string, unknown>
     )) {

--- a/src/mappers.ts
+++ b/src/mappers.ts
@@ -258,11 +258,9 @@ export async function toValue<
  *
  * Without a callback, the last non-`undefined` element wins.
  *
- * @remarks For arrays the callbacks run **concurrently**, so
- * using an accumulator for stateful reduction may yield
- * non-deterministic results with async callbacks. Use a
- * `ReadableStream` input or {@link toArray} + reduce for
- * ordered accumulation.
+ * All input types are processed **sequentially**, so stateful
+ * accumulation is always deterministic regardless of whether
+ * callbacks are async.
  *
  * @example
  * // Last element of an array
@@ -277,20 +275,31 @@ export async function toValue<
     callback || (((v: any) => v) as any),
   ])
 
+  const cb = callback as (...any: any[]) => any
   let value: any
 
-  await iterate(
-    iterable as IterableType,
-    async (...args: any[]) => {
-      const out = await (
-        callback as (...any: any[]) => any
-      )(...args, value)
-
-      if (out !== undefined) {
-        value = out
-      }
+  const apply = async (...args: any[]) => {
+    const out = await cb(...args, value)
+    if (out !== undefined) {
+      value = out
     }
-  )
+  }
+
+  const ReadableStream = await getReadableStream()
+
+  if (iterable instanceof ReadableStream) {
+    await iterate(iterable as IterableType, apply)
+  } else if (Array.isArray(iterable)) {
+    for (let i = 0; i < (iterable as any[]).length; i++) {
+      await apply((iterable as any[])[i], i)
+    }
+  } else if (typeof iterable === "object" && iterable !== null) {
+    for (const [key, val] of Object.entries(
+      iterable as Record<string, unknown>
+    )) {
+      await apply(val, key)
+    }
+  }
 
   return value
 }

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -348,6 +348,12 @@ describe("typectl", () => {
     expect(out).toContainEqual(["y", 2])
   })
 
+  it("iterate skips class instances", async () => {
+    const out: any[] = []
+    await iterate(new TestClass() as any, (v: any) => out.push(v))
+    expect(out).toEqual([])
+  })
+
   describe("toValue with falsy results", () => {
     it("reduces to 0", async () => {
       const out = await toValue([1, 2, 3], () => 0)
@@ -363,6 +369,32 @@ describe("typectl", () => {
       const out = await toValue([1], () => false)
       expect(out).toBe(false)
     })
+  })
+
+  it("toValue is sequential and deterministic for arrays", async () => {
+    const order: number[] = []
+    const out = await toValue(
+      [1, 2, 3],
+      async (v: number, _i: number, acc: number | undefined) => {
+        order.push(v)
+        return (acc ?? 0) + v
+      }
+    )
+    expect(order).toEqual([1, 2, 3])
+    expect(out).toBe(6)
+  })
+
+  it("toValue is sequential and deterministic for records", async () => {
+    const order: string[] = []
+    const out = await toValue(
+      { a: 1, b: 2, c: 3 } as Record<string, number>,
+      async (v: number, k: any, acc: number | undefined) => {
+        order.push(k)
+        return (acc ?? 0) + v
+      }
+    )
+    expect(order).toEqual(["a", "b", "c"])
+    expect(out).toBe(6)
   })
 
   it("toStream propagates callback errors", async () => {

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -350,7 +350,9 @@ describe("typectl", () => {
 
   it("iterate skips class instances", async () => {
     const out: any[] = []
-    await iterate(new TestClass() as any, (v: any) => out.push(v))
+    await iterate(new TestClass() as any, (v: any) =>
+      out.push(v)
+    )
     expect(out).toEqual([])
   })
 
@@ -375,7 +377,11 @@ describe("typectl", () => {
     const order: number[] = []
     const out = await toValue(
       [1, 2, 3],
-      async (v: number, _i: number, acc: number | undefined) => {
+      async (
+        v: number,
+        _i: number,
+        acc: number | undefined
+      ) => {
         order.push(v)
         return (acc ?? 0) + v
       }
@@ -388,7 +394,11 @@ describe("typectl", () => {
     const order: string[] = []
     const out = await toValue(
       { a: 1, b: 2, c: 3 } as Record<string, number>,
-      async (v: number, k: any, acc: number | undefined) => {
+      async (
+        v: number,
+        k: any,
+        acc: number | undefined
+      ) => {
         order.push(k)
         return (acc ?? 0) + v
       }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
     include: ["src/**/spec.ts"],
     coverage: {
       provider: "v8",
-      include: ["src/typectl.ts"],
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/spec.ts", "src/example/**"],
     },
   },
 })


### PR DESCRIPTION
## Summary

- **`toValue` is now always sequential.** Previously, array inputs ran callbacks concurrently via `Promise.all`, making stateful async reductions non-deterministic (a footgun for anyone expecting `reduce`-like behaviour). All input types — arrays, records, and streams — are now processed one element at a time, so the accumulator is always updated in order.

- **`iterate` now rejects class instances as records.** The record branch previously matched any `typeof === "object"` value, silently running `Object.entries` on class instances and picking up their enumerable own properties. The check now requires `Object.getPrototypeOf(iterable) === Object.prototype` (or `null`), so only plain object literals and `Object.create(null)` objects are treated as records; class instances are skipped.

- **Coverage config now measures real implementation.** `vitest` coverage was scoped to `src/typectl.ts` (the barrel re-export), so reported line/branch numbers were meaningless. The `include` glob is now `src/**/*.ts` with specs and examples excluded, giving accurate coverage across `wrap.ts`, `mappers.ts`, `iterate.ts`, etc.

## Test plan

- [ ] `npm test` — all 41 tests pass
- [ ] New test: `toValue is sequential and deterministic for arrays` — verifies visit order and sum
- [ ] New test: `toValue is sequential and deterministic for records` — verifies visit order and sum
- [ ] New test: `iterate skips class instances` — verifies empty output for a class instance input
- [ ] Run `npm run test:coverage` and confirm implementation modules appear in the report

Made with [Cursor](https://cursor.com)